### PR TITLE
support for scoping sheet by batch load date (since cannot be queried)

### DIFF
--- a/Java/src/main/java/com/nuix/superutilities/reporting/IntersectionReportSheetConfiguration.java
+++ b/Java/src/main/java/com/nuix/superutilities/reporting/IntersectionReportSheetConfiguration.java
@@ -4,6 +4,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.BiFunction;
 
+import org.joda.time.DateTime;
+
 import nuix.Case;
 
 public class IntersectionReportSheetConfiguration {
@@ -14,6 +16,8 @@ public class IntersectionReportSheetConfiguration {
 	private String rowCategoryLabel = "Term";
 	private String colPrimaryCategoryLabel = "Column Category";
 	private String scopeQuery = "";
+	private DateTime batchLoadMinDate = null;
+	private DateTime batchLoadMaxDate = null;
 	private boolean freezePanes = false;
 	
 	/***
@@ -163,6 +167,42 @@ public class IntersectionReportSheetConfiguration {
 	 */
 	public void setScopeQuery(String scopeQuery) {
 		this.scopeQuery = scopeQuery;
+	}
+	
+	/***
+	 * Gets the minimum batch load date an item must have to be reported.  A null value means batch load date is not to be considered.
+	 * @return the minimum batch load date an item must have to be reported
+	 */
+	public DateTime getBatchLoadMinDate() {
+		return batchLoadMinDate;
+	}
+
+	/***
+	 * Sets the minimum batch load date an item must have to be reported.  A null value means batch load date is not to be considered.
+	 * @param batchLoadMinDate the minimum batch load date an item must have to be reported
+	 */
+	public void setBatchLoadMinDate(DateTime batchLoadMinDate) {
+		this.batchLoadMinDate = batchLoadMinDate;
+	}
+
+	/***
+	 * Gets the maximum batch load date an item must have to be reported.  A null value means batch load date is not to be considered.
+	 * @return the maximum batch load date an item must have to be reported
+	 */
+	public DateTime getBatchLoadMaxDate() {
+		return batchLoadMaxDate;
+	}
+
+	/***
+	 * Sets the maximum batch load date an item must have to be reported.  A null value means batch load date is not to be considered.
+	 * @param batchLoadMaxDate the maximum batch load date an item must have to be reported
+	 */
+	public void setBatchLoadMaxDate(DateTime batchLoadMaxDate) {
+		this.batchLoadMaxDate = batchLoadMaxDate;
+	}
+	
+	public boolean hasBatchLoadDateCriteria() {
+		return batchLoadMinDate != null || batchLoadMaxDate != null;
 	}
 
 	/***


### PR DESCRIPTION
Added batch load date range scoping to code for intersection report.  Since (at this time) you cannot run a Nuix query to filter by batch load date (only batch load GUID), this change adds support by taking the given min/max datetime values, filtering all the batch loads in the case to those which fall within the range, and then appending an appropriate batch load GUID query to the scope query.